### PR TITLE
Score benchmark latency from successful content

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,31 +9,31 @@ status **and** the response body contains the page's expected text.
 
 | Rank | Provider         | Success rate | Latency score |  Passed |
 | ---: | ---------------- | -----------: | ------------: | ------: |
-|    1 | string_unblocker |        95.8% |       9.76s | 431/450 |
-|    2 | scrapfly         |        83.6% |      12.21s | 376/450 |
-|    3 | bright           |        80.9% |      24.25s | 364/450 |
-|    4 | context_dev      |        78.7% |      12.13s | 354/450 |
-|    5 | firecrawl        |        70.9% |       8.43s | 319/450 |
-|    6 | scraperapi       |        69.3% |      14.08s | 312/450 |
-|    7 | oxylabs          |        68.9% |      21.31s | 310/450 |
-|    8 | zyte             |        68.2% |      15.55s | 307/450 |
-|    9 | decodo           |        67.8% |      31.75s | 305/450 |
-|   10 | nimble           |        59.3% |      30.03s | 267/450 |
-|   11 | browserbase      |        50.0% |       2.49s | 225/450 |
-|   12 | zenrows          |        44.2% |      15.37s | 199/450 |
-|   13 | scrapingant      |        35.1% |       5.49s | 158/450 |
-|   14 | scrapingdog      |        35.1% |       4.89s | 158/450 |
-|   15 | scrapingbee      |        33.3% |       7.74s | 150/450 |
+|    1 | string_unblocker |        95.8% |      11.07s | 431/450 |
+|    2 | scrapfly         |        83.6% |      14.28s | 376/450 |
+|    3 | bright           |        80.9% |      24.33s | 364/450 |
+|    4 | context_dev      |        78.7% |      13.62s | 354/450 |
+|    5 | firecrawl        |        70.9% |      14.70s | 319/450 |
+|    6 | scraperapi       |        69.3% |      13.31s | 312/450 |
+|    7 | oxylabs          |        68.9% |      20.85s | 310/450 |
+|    8 | zyte             |        68.2% |      17.50s | 307/450 |
+|    9 | decodo           |        67.8% |      29.74s | 305/450 |
+|   10 | nimble           |        59.3% |      21.43s | 267/450 |
+|   11 | browserbase      |        50.0% |      15.25s | 225/450 |
+|   12 | zenrows          |        44.2% |      21.35s | 199/450 |
+|   13 | scrapingant      |        35.1% |      15.46s | 158/450 |
+|   14 | scrapingdog      |        35.1% |      15.01s | 158/450 |
+|   15 | scrapingbee      |        33.3% |      18.15s | 150/450 |
 
 ## Latency scoring
 
-Latency is an equal-weighted average across target URLs. A target with at least one verified-content
-success uses its observed mean wall-clock latency across its attempts. A target with no verified-content
-success is still included, but receives the greater of its 75th-percentile latency and its all-attempt mean.
-This prevents a fast all-failure — including one with a slow timeout outlier — from improving a provider's
-latency score while leaving the success-rate calculation unchanged. The percentile uses linear
-interpolation; with the benchmark's five attempts per target, it is the fourth of five timings after sorting
-from fastest to slowest.
+Latency is an equal-weighted average across target URLs. For a provider that returns verified content,
+the target score is the nearest-rank 75th percentile of its successful attempt latencies; failed attempts
+do not contribute a fast response time. For a provider with no verified-content response for a target, the
+score is the nearest-rank 75th percentile of the successful providers' target scores. If nobody succeeds
+on a target, the score is the benchmark's 90-second timeout. Nearest-rank p75 uses
+`ceil(0.75 × n)`: one successful value uses that value, two use the slower value, and five use the fourth
+value after sorting fastest to slowest.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -10,18 +10,18 @@ status **and** the response body contains the page's expected text.
 | Rank | Provider         | Success rate | Latency score |  Passed |
 | ---: | ---------------- | -----------: | ------------: | ------: |
 |    1 | string_unblocker |        95.8% |       9.76s | 431/450 |
-|    2 | scrapfly         |        83.6% |      12.19s | 376/450 |
-|    3 | bright           |        80.9% |      24.21s | 364/450 |
-|    4 | context_dev      |        78.7% |      12.09s | 354/450 |
-|    5 | firecrawl        |        70.9% |       8.37s | 319/450 |
+|    2 | scrapfly         |        83.6% |      12.21s | 376/450 |
+|    3 | bright           |        80.9% |      24.25s | 364/450 |
+|    4 | context_dev      |        78.7% |      12.13s | 354/450 |
+|    5 | firecrawl        |        70.9% |       8.43s | 319/450 |
 |    6 | scraperapi       |        69.3% |      14.08s | 312/450 |
 |    7 | oxylabs          |        68.9% |      21.31s | 310/450 |
-|    8 | zyte             |        68.2% |      15.54s | 307/450 |
+|    8 | zyte             |        68.2% |      15.55s | 307/450 |
 |    9 | decodo           |        67.8% |      31.75s | 305/450 |
-|   10 | nimble           |        59.3% |      29.97s | 267/450 |
-|   11 | browserbase      |        50.0% |       2.48s | 225/450 |
-|   12 | zenrows          |        44.2% |      15.31s | 199/450 |
-|   13 | scrapingant      |        35.1% |       5.39s | 158/450 |
+|   10 | nimble           |        59.3% |      30.03s | 267/450 |
+|   11 | browserbase      |        50.0% |       2.49s | 225/450 |
+|   12 | zenrows          |        44.2% |      15.37s | 199/450 |
+|   13 | scrapingant      |        35.1% |       5.49s | 158/450 |
 |   14 | scrapingdog      |        35.1% |       4.89s | 158/450 |
 |   15 | scrapingbee      |        33.3% |       7.46s | 150/450 |
 
@@ -29,10 +29,11 @@ status **and** the response body contains the page's expected text.
 
 Latency is an equal-weighted average across target URLs. A target with at least one verified-content
 success uses its observed mean wall-clock latency across its attempts. A target with no verified-content
-success is still included, but receives the 75th-percentile latency from its own attempts instead of the
-mean of its failures. This prevents a fast all-failure from improving a provider's latency score while
-leaving the success-rate calculation unchanged. The percentile uses linear interpolation; with the
-benchmark's five attempts per target, it is the fourth of five timings after sorting from fastest to slowest.
+success is still included, but receives the greater of its 75th-percentile latency and its all-attempt mean.
+This prevents a fast all-failure — including one with a slow timeout outlier — from improving a provider's
+latency score while leaving the success-rate calculation unchanged. The percentile uses linear
+interpolation; with the benchmark's five attempts per target, it is the fourth of five timings after sorting
+from fastest to slowest.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -1,29 +1,38 @@
 # Web Data Frontier Benchmark
 
-Compare web access APIs (web unblockers / scrape APIs) head-to-head against a fixed suite of ~50
+Compare web access APIs (web unblockers / scrape APIs) head-to-head against a fixed suite of 90
 real-world, bot-protected URLs (Amazon, Walmart, Zillow, Cloudflare/PerimeterX-guarded retail and travel
 sites, etc.). Each provider is sent the same URLs; a request **passes** when the API returns a `2xx`
 status **and** the response body contains the page's expected text.
 
 ## Results
 
-| Rank | Provider         | Success rate | Avg latency |  Passed |
-| ---: | ---------------- | -----------: | ----------: | ------: |
-|    1 | string_unblocker |        95.8% |       9.70s | 431/450 |
-|    2 | scrapfly         |        83.6% |      12.01s | 376/450 |
-|    3 | bright           |        80.9% |      24.23s | 364/450 |
-|    4 | context_dev      |        78.7% |      11.86s | 354/450 |
-|    5 | firecrawl        |        70.9% |       8.38s | 319/450 |
-|    6 | scraperapi       |        69.3% |      13.71s | 312/450 |
-|    7 | oxylabs          |        68.9% |      20.73s | 310/450 |
-|    8 | zyte             |        68.2% |      15.15s | 307/450 |
-|    9 | decodo           |        67.8% |      31.54s | 305/450 |
-|   10 | nimble           |        59.3% |      27.21s | 267/450 |
-|   11 | browserbase      |        50.0% |       2.43s | 225/450 |
-|   12 | zenrows          |        44.2% |      14.97s | 199/450 |
-|   13 | scrapingant      |        35.1% |       5.09s | 158/450 |
-|   14 | scrapingdog      |        35.1% |       4.61s | 158/450 |
-|   15 | scrapingbee      |        33.3% |       7.20s | 150/450 |
+| Rank | Provider         | Success rate | Latency score |  Passed |
+| ---: | ---------------- | -----------: | ------------: | ------: |
+|    1 | string_unblocker |        95.8% |       9.76s | 431/450 |
+|    2 | scrapfly         |        83.6% |      12.19s | 376/450 |
+|    3 | bright           |        80.9% |      24.21s | 364/450 |
+|    4 | context_dev      |        78.7% |      12.09s | 354/450 |
+|    5 | firecrawl        |        70.9% |       8.37s | 319/450 |
+|    6 | scraperapi       |        69.3% |      14.08s | 312/450 |
+|    7 | oxylabs          |        68.9% |      21.31s | 310/450 |
+|    8 | zyte             |        68.2% |      15.54s | 307/450 |
+|    9 | decodo           |        67.8% |      31.75s | 305/450 |
+|   10 | nimble           |        59.3% |      29.97s | 267/450 |
+|   11 | browserbase      |        50.0% |       2.48s | 225/450 |
+|   12 | zenrows          |        44.2% |      15.31s | 199/450 |
+|   13 | scrapingant      |        35.1% |       5.39s | 158/450 |
+|   14 | scrapingdog      |        35.1% |       4.89s | 158/450 |
+|   15 | scrapingbee      |        33.3% |       7.46s | 150/450 |
+
+## Latency scoring
+
+Latency is an equal-weighted average across target URLs. A target with at least one verified-content
+success uses its observed mean wall-clock latency across its attempts. A target with no verified-content
+success is still included, but receives the 75th-percentile latency from its own attempts instead of the
+mean of its failures. This prevents a fast all-failure from improving a provider's latency score while
+leaving the success-rate calculation unchanged. The percentile uses linear interpolation; with the
+benchmark's five attempts per target, it is the fourth of five timings after sorting from fastest to slowest.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ status **and** the response body contains the page's expected text.
 |   12 | zenrows          |        44.2% |      15.37s | 199/450 |
 |   13 | scrapingant      |        35.1% |       5.49s | 158/450 |
 |   14 | scrapingdog      |        35.1% |       4.89s | 158/450 |
-|   15 | scrapingbee      |        33.3% |       7.46s | 150/450 |
+|   15 | scrapingbee      |        33.3% |       7.74s | 150/450 |
 
 ## Latency scoring
 

--- a/README.md
+++ b/README.md
@@ -1,42 +1,29 @@
 # Web Data Frontier Benchmark
 
-Compare web access APIs (web unblockers / scrape APIs) head-to-head against a fixed suite of 90
+Compare web access APIs (web unblockers / scrape APIs) head-to-head against a fixed suite of ~50
 real-world, bot-protected URLs (Amazon, Walmart, Zillow, Cloudflare/PerimeterX-guarded retail and travel
 sites, etc.). Each provider is sent the same URLs; a request **passes** when the API returns a `2xx`
 status **and** the response body contains the page's expected text.
 
 ## Results
 
-| Rank | Provider         | Success rate | Latency score |  Passed |
-| ---: | ---------------- | -----------: | ------------: | ------: |
-|    1 | string_unblocker |        95.8% |      11.07s | 431/450 |
-|    2 | scrapfly         |        83.6% |      14.28s | 376/450 |
-|    3 | bright           |        80.9% |      24.33s | 364/450 |
-|    4 | context_dev      |        78.7% |      13.62s | 354/450 |
-|    5 | firecrawl        |        70.9% |      14.70s | 319/450 |
-|    6 | scraperapi       |        69.3% |      13.31s | 312/450 |
-|    7 | oxylabs          |        68.9% |      20.85s | 310/450 |
-|    8 | zyte             |        68.2% |      17.50s | 307/450 |
-|    9 | decodo           |        67.8% |      29.74s | 305/450 |
-|   10 | nimble           |        59.3% |      21.43s | 267/450 |
-|   11 | browserbase      |        50.0% |      15.25s | 225/450 |
-|   12 | zenrows          |        44.2% |      21.35s | 199/450 |
-|   13 | scrapingant      |        35.1% |      15.46s | 158/450 |
-|   14 | scrapingdog      |        35.1% |      15.01s | 158/450 |
-|   15 | scrapingbee      |        33.3% |      18.15s | 150/450 |
-
-## Latency scoring
-
-Latency is an equal-weighted average across target URLs. For a provider that returns verified content,
-the target score is the nearest-rank 75th percentile of its successful attempt latencies; failed attempts
-do not contribute a fast response time. For a provider with no verified-content response for a target, the
-score is the nearest-rank 75th percentile of the successful providers' target scores. If nobody succeeds
-on a target, the score is the benchmark's 90-second timeout. Nearest-rank p75 uses
-`ceil(0.75 × n)`: one successful value uses that value, two use the slower value, and five use the fourth
-value after sorting fastest to slowest.
-
-The CLI's per-provider, per-target output labels the value included in the leaderboard as `Resolved latency`
-and identifies whether it came from successful attempts, successful providers, or the timeout.
+| Rank | Provider         | Success rate | Avg latency |  Passed |
+| ---: | ---------------- | -----------: | ----------: | ------: |
+|    1 | string_unblocker |        95.8% |       9.70s | 431/450 |
+|    2 | scrapfly         |        83.6% |      12.01s | 376/450 |
+|    3 | bright           |        80.9% |      24.23s | 364/450 |
+|    4 | context_dev      |        78.7% |      11.86s | 354/450 |
+|    5 | firecrawl        |        70.9% |       8.38s | 319/450 |
+|    6 | scraperapi       |        69.3% |      13.71s | 312/450 |
+|    7 | oxylabs          |        68.9% |      20.73s | 310/450 |
+|    8 | zyte             |        68.2% |      15.15s | 307/450 |
+|    9 | decodo           |        67.8% |      31.54s | 305/450 |
+|   10 | nimble           |        59.3% |      27.21s | 267/450 |
+|   11 | browserbase      |        50.0% |       2.43s | 225/450 |
+|   12 | zenrows          |        44.2% |      14.97s | 199/450 |
+|   13 | scrapingant      |        35.1% |       5.09s | 158/450 |
+|   14 | scrapingdog      |        35.1% |       4.61s | 158/450 |
+|   15 | scrapingbee      |        33.3% |       7.20s | 150/450 |
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ on a target, the score is the benchmark's 90-second timeout. Nearest-rank p75 us
 `ceil(0.75 × n)`: one successful value uses that value, two use the slower value, and five use the fourth
 value after sorting fastest to slowest.
 
+The CLI's per-provider, per-target output labels the value included in the leaderboard as `Resolved latency`
+and identifies whether it came from successful attempts, successful providers, or the timeout.
+
 ## How it works
 
 - **Test suite** (`src/tests.const.ts`): each fixture is `{ name, url, containsText? }`.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "scripts": {
     "benchmark": "tsx src/cli.ts",
     "typecheck": "tsc --noEmit",
-    "build": "tsc"
+    "build": "tsc",
+    "test": "npm run build && node --test dist/format.test.js"
   },
   "dependencies": {
     "@browserbasehq/sdk": "2.8.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -140,8 +140,9 @@ async function main(): Promise<void> {
   await Promise.all(Array.from({ length: providerWorkers }, () => providerWorker()));
 
   console.log("\n=== Comparison ===");
-  console.log(formatComparisonTable(runs));
-  for (const run of runs) console.log(formatProviderSummary(run));
+  console.log(formatComparisonTable(runs, config.timeoutMs));
+  const comparisonResults = runs.map((run) => run.result);
+  for (const run of runs) console.log(formatProviderSummary(run, comparisonResults, config.timeoutMs));
 
   const outPath = opts.out ?? join("results", `benchmark-${new Date().toISOString().replace(/[:.]/g, "-")}.json`);
   saveResultsJSON(runs, outPath);

--- a/src/format.test.ts
+++ b/src/format.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { comparisonAverageLatencyMs, comparisonLatencyMs, NO_SUCCESSFUL_PROVIDER_LATENCY_MS } from "./format.js";
+import type { AttemptResult, WebAccessAggregatedResult, WebAccessBenchmarkResult } from "./types.js";
+
+function target(testName: string, attempts: AttemptResult[]): WebAccessAggregatedResult {
+  const latencies = attempts.map((attempt) => attempt.latencyMs);
+  const successCount = attempts.filter((attempt) => attempt.success).length;
+  return {
+    testName,
+    url: `https://${testName}.example`,
+    totalAttempts: attempts.length,
+    successCount,
+    successRate: successCount / attempts.length,
+    avgLatencyMs: latencies.reduce((sum, latency) => sum + latency, 0) / latencies.length,
+    minLatencyMs: Math.min(...latencies),
+    maxLatencyMs: Math.max(...latencies),
+    errors: [],
+    attempts
+  };
+}
+
+function run(...results: WebAccessAggregatedResult[]): WebAccessBenchmarkResult {
+  const totalRequests = results.reduce((sum, result) => sum + result.totalAttempts, 0);
+  const successfulRequests = results.reduce((sum, result) => sum + result.successCount, 0);
+  return {
+    durationMs: 0,
+    totalRequests,
+    successfulRequests,
+    overallSuccessRate: successfulRequests / totalRequests,
+    results
+  };
+}
+
+test("uses nearest-rank p75 over successful attempts", () => {
+  const result = target("partial", [
+    { success: false, latencyMs: 1 },
+    { success: true, latencyMs: 100 },
+    { success: true, latencyMs: 200 }
+  ]);
+
+  assert.equal(comparisonLatencyMs(result), 200);
+});
+
+test("uses the successful providers on a target for a total failure", () => {
+  const failed = run(target("shared", [{ success: false, latencyMs: 1 }]));
+  const firstSuccess = run(target("shared", [{ success: true, latencyMs: 100 }, { success: true, latencyMs: 200 }]));
+  const secondSuccess = run(target("shared", [{ success: true, latencyMs: 300 }]));
+
+  assert.equal(comparisonAverageLatencyMs(failed, [failed, firstSuccess, secondSuccess]), 300);
+});
+
+test("uses the benchmark timeout when no provider succeeds", () => {
+  const failed = target("unsolved", [{ success: false, latencyMs: 1 }]);
+
+  assert.equal(comparisonLatencyMs(failed), NO_SUCCESSFUL_PROVIDER_LATENCY_MS);
+});

--- a/src/format.test.ts
+++ b/src/format.test.ts
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { comparisonAverageLatencyMs, comparisonLatencyMs, NO_SUCCESSFUL_PROVIDER_LATENCY_MS } from "./format.js";
+import {
+  comparisonAverageLatencyMs,
+  comparisonLatencyMs,
+  formatProviderSummary,
+  NO_SUCCESSFUL_PROVIDER_LATENCY_MS,
+  resolveComparisonLatency
+} from "./format.js";
 import type { AttemptResult, WebAccessAggregatedResult, WebAccessBenchmarkResult } from "./types.js";
 
 function target(testName: string, attempts: AttemptResult[]): WebAccessAggregatedResult {
@@ -54,4 +60,16 @@ test("uses the benchmark timeout when no provider succeeds", () => {
   const failed = target("unsolved", [{ success: false, latencyMs: 1 }]);
 
   assert.equal(comparisonLatencyMs(failed), NO_SUCCESSFUL_PROVIDER_LATENCY_MS);
+});
+
+test("shows the resolved latency and its source in each target row", () => {
+  const failed = run(target("shared", [{ success: false, latencyMs: 1 }]));
+  const firstSuccess = run(target("shared", [{ success: true, latencyMs: 100 }, { success: true, latencyMs: 200 }]));
+  const secondSuccess = run(target("shared", [{ success: true, latencyMs: 300 }]));
+  const resolvedLatency = resolveComparisonLatency(failed.results[0], [200, 300]);
+  const summary = formatProviderSummary({ provider: "failed", result: failed }, [failed, firstSuccess, secondSuccess]);
+
+  assert.deepEqual(resolvedLatency, { latencyMs: 300, source: "successful providers" });
+  assert.match(summary, /Resolved latency/);
+  assert.match(summary, /0\.30s\s+successful providers\s+shared/);
 });

--- a/src/format.ts
+++ b/src/format.ts
@@ -20,7 +20,7 @@ function quantile(values: readonly number[], percentile: number): number {
 
 export function comparisonLatencyMs(result: WebAccessAggregatedResult): number {
   if (result.successCount > 0 || result.attempts.length === 0) return result.avgLatencyMs;
-  return quantile(result.attempts.map((attempt) => attempt.latencyMs), 0.75);
+  return Math.max(result.avgLatencyMs, quantile(result.attempts.map((attempt) => attempt.latencyMs), 0.75));
 }
 
 export function comparisonAverageLatencyMs(result: WebAccessBenchmarkResult): number {

--- a/src/format.ts
+++ b/src/format.ts
@@ -9,22 +9,50 @@ export interface ProviderRun {
 
 const pct = (n: number): string => `${(n * 100).toFixed(1)}%`;
 const secs = (ms: number): string => `${(ms / 1000).toFixed(2)}s`;
+const P75 = 0.75;
+export const NO_SUCCESSFUL_PROVIDER_LATENCY_MS = 90_000;
 
-function quantile(values: readonly number[], percentile: number): number {
+function nearestRank(values: readonly number[], percentile: number): number | undefined {
+  if (values.length === 0) return undefined;
   const sorted = [...values].sort((a, b) => a - b);
-  const index = (sorted.length - 1) * percentile;
-  const lower = Math.floor(index);
-  const upper = Math.ceil(index);
-  return sorted[lower] + (sorted[upper] - sorted[lower]) * (index - lower);
+  return sorted[Math.ceil(sorted.length * percentile) - 1];
 }
 
-export function comparisonLatencyMs(result: WebAccessAggregatedResult): number {
-  if (result.successCount > 0 || result.attempts.length === 0) return result.avgLatencyMs;
-  return Math.max(result.avgLatencyMs, quantile(result.attempts.map((attempt) => attempt.latencyMs), 0.75));
+function successfulLatencyMs(result: WebAccessAggregatedResult): number | undefined {
+  return nearestRank(
+    result.attempts.filter((attempt) => attempt.success).map((attempt) => attempt.latencyMs),
+    P75
+  );
 }
 
-export function comparisonAverageLatencyMs(result: WebAccessBenchmarkResult): number {
-  const latencies = result.results.map(comparisonLatencyMs);
+function successfulLatenciesByTest(results: readonly WebAccessBenchmarkResult[]): Map<string, number[]> {
+  return results.flatMap((result) => result.results).reduce((latenciesByTest, result) => {
+    const latency = successfulLatencyMs(result);
+    if (latency === undefined) return latenciesByTest;
+    const latencies = latenciesByTest.get(result.testName) ?? [];
+    latencies.push(latency);
+    latenciesByTest.set(result.testName, latencies);
+    return latenciesByTest;
+  }, new Map<string, number[]>());
+}
+
+export function comparisonLatencyMs(
+  result: WebAccessAggregatedResult,
+  peerSuccessfulLatencies: readonly number[] = [],
+  noSuccessfulProviderLatencyMs = NO_SUCCESSFUL_PROVIDER_LATENCY_MS
+): number {
+  return successfulLatencyMs(result) ?? nearestRank(peerSuccessfulLatencies, P75) ?? noSuccessfulProviderLatencyMs;
+}
+
+export function comparisonAverageLatencyMs(
+  result: WebAccessBenchmarkResult,
+  comparisonResults: readonly WebAccessBenchmarkResult[] = [result],
+  noSuccessfulProviderLatencyMs = NO_SUCCESSFUL_PROVIDER_LATENCY_MS
+): number {
+  const latenciesByTest = successfulLatenciesByTest(comparisonResults);
+  const latencies = result.results.map((target) =>
+    comparisonLatencyMs(target, latenciesByTest.get(target.testName), noSuccessfulProviderLatencyMs)
+  );
   return latencies.reduce((sum, latency) => sum + latency, 0) / Math.max(latencies.length, 1);
 }
 
@@ -33,12 +61,13 @@ function padRow(cells: string[], widths: number[]): string {
 }
 
 /** Leaderboard across providers, sorted by overall success rate. */
-export function formatComparisonTable(runs: ProviderRun[]): string {
+export function formatComparisonTable(runs: ProviderRun[], noSuccessfulProviderLatencyMs = NO_SUCCESSFUL_PROVIDER_LATENCY_MS): string {
   const header = ["Provider", "Success Rate", "Latency Score", "Requests"];
+  const comparisonResults = runs.map((run) => run.result);
   const rows = [...runs]
     .sort((a, b) => b.result.overallSuccessRate - a.result.overallSuccessRate)
     .map((r) => {
-      const avgLatency = comparisonAverageLatencyMs(r.result);
+      const avgLatency = comparisonAverageLatencyMs(r.result, comparisonResults, noSuccessfulProviderLatencyMs);
       return [
         r.provider,
         pct(r.result.overallSuccessRate),
@@ -53,11 +82,18 @@ export function formatComparisonTable(runs: ProviderRun[]): string {
 }
 
 /** Per-test breakdown for a single provider. */
-export function formatProviderSummary(run: ProviderRun): string {
+export function formatProviderSummary(
+  run: ProviderRun,
+  comparisonResults: readonly WebAccessBenchmarkResult[] = [run.result],
+  noSuccessfulProviderLatencyMs = NO_SUCCESSFUL_PROVIDER_LATENCY_MS
+): string {
+  const latenciesByTest = successfulLatenciesByTest(comparisonResults);
   const lines = [`\n${run.provider} — ${pct(run.result.overallSuccessRate)} over ${run.result.totalRequests} requests`];
   for (const test of [...run.result.results].sort((a, b) => b.successRate - a.successRate)) {
     const errs = test.errors.length ? `  [${test.errors.join("; ")}]` : "";
-    lines.push(`  ${pct(test.successRate).padStart(6)}  ${secs(test.avgLatencyMs).padStart(7)}  ${test.testName}${errs}`);
+    lines.push(
+      `  ${pct(test.successRate).padStart(6)}  ${secs(comparisonLatencyMs(test, latenciesByTest.get(test.testName), noSuccessfulProviderLatencyMs)).padStart(7)}  ${test.testName}${errs}`
+    );
   }
   return lines.join("\n");
 }

--- a/src/format.ts
+++ b/src/format.ts
@@ -36,12 +36,33 @@ function successfulLatenciesByTest(results: readonly WebAccessBenchmarkResult[])
   }, new Map<string, number[]>());
 }
 
+export type ResolvedLatencySource = "successful attempts" | "successful providers" | "timeout";
+
+export interface ResolvedLatency {
+  latencyMs: number;
+  source: ResolvedLatencySource;
+}
+
+export function resolveComparisonLatency(
+  result: WebAccessAggregatedResult,
+  peerSuccessfulLatencies: readonly number[] = [],
+  noSuccessfulProviderLatencyMs = NO_SUCCESSFUL_PROVIDER_LATENCY_MS
+): ResolvedLatency {
+  const successfulLatency = successfulLatencyMs(result);
+  if (successfulLatency !== undefined) return { latencyMs: successfulLatency, source: "successful attempts" };
+
+  const peerLatency = nearestRank(peerSuccessfulLatencies, P75);
+  if (peerLatency !== undefined) return { latencyMs: peerLatency, source: "successful providers" };
+
+  return { latencyMs: noSuccessfulProviderLatencyMs, source: "timeout" };
+}
+
 export function comparisonLatencyMs(
   result: WebAccessAggregatedResult,
   peerSuccessfulLatencies: readonly number[] = [],
   noSuccessfulProviderLatencyMs = NO_SUCCESSFUL_PROVIDER_LATENCY_MS
 ): number {
-  return successfulLatencyMs(result) ?? nearestRank(peerSuccessfulLatencies, P75) ?? noSuccessfulProviderLatencyMs;
+  return resolveComparisonLatency(result, peerSuccessfulLatencies, noSuccessfulProviderLatencyMs).latencyMs;
 }
 
 export function comparisonAverageLatencyMs(
@@ -88,11 +109,15 @@ export function formatProviderSummary(
   noSuccessfulProviderLatencyMs = NO_SUCCESSFUL_PROVIDER_LATENCY_MS
 ): string {
   const latenciesByTest = successfulLatenciesByTest(comparisonResults);
-  const lines = [`\n${run.provider} — ${pct(run.result.overallSuccessRate)} over ${run.result.totalRequests} requests`];
+  const lines = [
+    `\n${run.provider} — ${pct(run.result.overallSuccessRate)} over ${run.result.totalRequests} requests`,
+    `  ${"Success".padStart(6)}  ${"Resolved latency".padStart(16)}  ${"Source".padEnd(20)}  Target`
+  ];
   for (const test of [...run.result.results].sort((a, b) => b.successRate - a.successRate)) {
     const errs = test.errors.length ? `  [${test.errors.join("; ")}]` : "";
+    const resolvedLatency = resolveComparisonLatency(test, latenciesByTest.get(test.testName), noSuccessfulProviderLatencyMs);
     lines.push(
-      `  ${pct(test.successRate).padStart(6)}  ${secs(comparisonLatencyMs(test, latenciesByTest.get(test.testName), noSuccessfulProviderLatencyMs)).padStart(7)}  ${test.testName}${errs}`
+      `  ${pct(test.successRate).padStart(6)}  ${secs(resolvedLatency.latencyMs).padStart(16)}  ${resolvedLatency.source.padEnd(20)}  ${test.testName}${errs}`
     );
   }
   return lines.join("\n");

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
-import type { WebAccessBenchmarkResult } from "./types.js";
+import type { WebAccessAggregatedResult, WebAccessBenchmarkResult } from "./types.js";
 
 export interface ProviderRun {
   provider: string;
@@ -10,18 +10,35 @@ export interface ProviderRun {
 const pct = (n: number): string => `${(n * 100).toFixed(1)}%`;
 const secs = (ms: number): string => `${(ms / 1000).toFixed(2)}s`;
 
+function quantile(values: readonly number[], percentile: number): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = (sorted.length - 1) * percentile;
+  const lower = Math.floor(index);
+  const upper = Math.ceil(index);
+  return sorted[lower] + (sorted[upper] - sorted[lower]) * (index - lower);
+}
+
+export function comparisonLatencyMs(result: WebAccessAggregatedResult): number {
+  if (result.successCount > 0 || result.attempts.length === 0) return result.avgLatencyMs;
+  return quantile(result.attempts.map((attempt) => attempt.latencyMs), 0.75);
+}
+
+export function comparisonAverageLatencyMs(result: WebAccessBenchmarkResult): number {
+  const latencies = result.results.map(comparisonLatencyMs);
+  return latencies.reduce((sum, latency) => sum + latency, 0) / Math.max(latencies.length, 1);
+}
+
 function padRow(cells: string[], widths: number[]): string {
   return cells.map((c, i) => c.padEnd(widths[i])).join(" | ");
 }
 
 /** Leaderboard across providers, sorted by overall success rate. */
 export function formatComparisonTable(runs: ProviderRun[]): string {
-  const header = ["Provider", "Success Rate", "Avg Latency", "Requests"];
+  const header = ["Provider", "Success Rate", "Latency Score", "Requests"];
   const rows = [...runs]
     .sort((a, b) => b.result.overallSuccessRate - a.result.overallSuccessRate)
     .map((r) => {
-      const avgLatency =
-        r.result.results.reduce((sum, t) => sum + t.avgLatencyMs, 0) / Math.max(r.result.results.length, 1);
+      const avgLatency = comparisonAverageLatencyMs(r.result);
       return [
         r.provider,
         pct(r.result.overallSuccessRate),

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,9 @@ export {
   comparisonLatencyMs,
   formatComparisonTable,
   formatProviderSummary,
+  resolveComparisonLatency,
   saveResultsJSON,
-  type ProviderRun
+  type ProviderRun,
+  type ResolvedLatency,
+  type ResolvedLatencySource
 } from "./format.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@ export { makeExecutor, runWebAccessBenchmarkSuite } from "./runner.js";
 export { WEB_ACCESS_ALL_TESTS, WEB_ACCESS_BENCHMARK_CONFIG } from "./tests.const.js";
 export { PROVIDERS, getProvider } from "./providers/index.js";
 export {
+  comparisonAverageLatencyMs,
+  comparisonLatencyMs,
   formatComparisonTable,
   formatProviderSummary,
   saveResultsJSON,


### PR DESCRIPTION
## Summary

- calculate each provider-target latency as the nearest-rank p75 of successful attempt latencies;
- fill a provider's complete miss from that target's successful-provider p75, using the configured 90-second timeout only if nobody succeeded; and
- add regression coverage and expose the resolved source in CLI output.

## Scope

This is the calculation-only stage. It does not regenerate the official raw result, public leaderboard values, or README copy. Those values will be recomputed separately by running the staged logic against the intended benchmark run.

Part of S-128083.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test`
