### PR TITLE
S-128690: Persist benchmark analysis reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ cp .env.example .env   # then fill in keys for the providers you want to test
 npm run benchmark      # Node (tsx)
 # or
 bun run src/cli.ts     # Bun
+
+# Recalculate a report from stored results without sending provider requests
+npm run analyze -- --in official_results/benchmark-2026-07-15T21-36-21-625Z.json --out results/recalculated-latency.txt
 ```
 
 A smoke test against a single provider and a single fixture:
@@ -57,19 +60,35 @@ A smoke test against a single provider and a single fixture:
 npm run benchmark -- --providers scrapfly --tests amazon --attempts 1
 ```
 
-## CLI options
+## Benchmark CLI options
 
 | Option              | Description                                                       |
 | ------------------- | ----------------------------------------------------------------- |
 | `--providers <a,b>` | Only run these providers (default: all with keys set)             |
 | `--tests <a,b>`     | Only run these fixtures by name (default: all)                    |
 | `--attempts <n>`    | Attempts per test (default: 5)                                    |
-| `--concurrency <n>` | Parallel requests per provider (default: 5)                       |
+| `--concurrency <n>` | Parallel requests per provider (default: 2)                       |
+| `--provider-concurrency <n>` | Providers to benchmark at once (default: 15)             |
 | `--out <file>`      | Results JSON path (default: `results/benchmark-<timestamp>.json`) |
+| `--report-out <file>` | Rendered report path (default: results path with `.txt`)        |
 | `-h, --help`        | Show help                                                         |
 
-Output is a comparison leaderboard plus a per-provider, per-test breakdown printed to the console, and the
-full structured results (every attempt) written to `results/`.
+Each benchmark run writes the full structured results (every attempt) to JSON and its comparison leaderboard
+plus per-provider, per-test breakdown to a companion text report. Use `--report-out` to choose another path.
+
+## Results analysis
+
+Recalculate the current scoring from a stored benchmark JSON file without calling providers:
+
+```bash
+npm run analyze -- --in official_results/benchmark-2026-07-15T21-36-21-625Z.json --out results/recalculated-latency.txt
+```
+
+| Option                    | Description                                                       |
+| ------------------------- | ----------------------------------------------------------------- |
+| `--in`, `--input <file>`  | Benchmark results JSON to analyze                                 |
+| `--out <file>`            | Rendered report path (default: `results/analysis-<timestamp>.txt`) |
+| `-h, --help`              | Show help                                                         |
 
 ## Supported providers
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "scripts": {
     "benchmark": "tsx src/cli.ts",
+    "analyze": "tsx src/analyze.ts",
     "typecheck": "tsc --noEmit",
     "build": "tsc",
     "test": "npm run build && node --test dist/format.test.js"

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -1,0 +1,88 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { formatComparisonReport, saveComparisonReport, type ProviderRun } from "./format.js";
+import type { WebAccessBenchmarkResult } from "./types.js";
+
+interface CliOptions {
+  input?: string;
+  out?: string;
+  help: boolean;
+}
+
+interface ResultsFile {
+  providers: Array<{ provider: string } & WebAccessBenchmarkResult>;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const opts: CliOptions = { help: false };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const next = (): string => argv[++i];
+    switch (arg) {
+      case "--in":
+      case "--input":
+        opts.input = next();
+        break;
+      case "--out":
+        opts.out = next();
+        break;
+      case "-h":
+      case "--help":
+        opts.help = true;
+        break;
+      default:
+        console.warn(`Unknown argument: ${arg}`);
+    }
+  }
+  return opts;
+}
+
+const HELP = `
+Web Data Frontier Benchmark — recalculate a report from stored benchmark results.
+
+Usage:
+  npm run analyze -- --in <results.json> [options]
+  bun run src/analyze.ts --in <results.json> [options]
+
+Options:
+  --in, --input <file>  Benchmark results JSON to analyze
+  --out <file>          Rendered report path (default: results/analysis-<timestamp>.txt)
+  -h, --help            Show this help
+
+This command reads stored attempts only. It does not call benchmark providers.
+`;
+
+function readRuns(inputPath: string): ProviderRun[] {
+  const resultsFile = JSON.parse(readFileSync(inputPath, "utf8")) as ResultsFile;
+  if (!Array.isArray(resultsFile.providers) || resultsFile.providers.some((run) => typeof run.provider !== "string")) {
+    throw new Error(`Invalid results file: ${inputPath}`);
+  }
+  return resultsFile.providers.map(({ provider, ...result }) => ({ provider, result }));
+}
+
+function main(): void {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.help) {
+    console.log(HELP);
+    return;
+  }
+  if (!opts.input) {
+    console.error("Missing --in <results.json>. See --help.");
+    process.exitCode = 1;
+    return;
+  }
+
+  const runs = readRuns(opts.input);
+  const report = formatComparisonReport(runs);
+  const outPath = opts.out ?? join("results", `analysis-${new Date().toISOString().replace(/[:.]/g, "-")}.txt`);
+  saveComparisonReport(report, outPath);
+  console.log(report);
+  console.log(`\nSaved report to ${outPath}`);
+}
+
+try {
+  main();
+} catch (e) {
+  console.error(e instanceof Error ? e.stack : String(e));
+  process.exitCode = 1;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 import "dotenv/config";
-import { join } from "node:path";
-import { formatComparisonTable, formatProviderSummary, saveResultsJSON, type ProviderRun } from "./format.js";
+import { extname, join } from "node:path";
+import { formatComparisonReport, saveComparisonReport, saveResultsJSON, type ProviderRun } from "./format.js";
 import { PROVIDERS } from "./providers/index.js";
 import { makeExecutor, runWebAccessBenchmarkSuite } from "./runner.js";
 import { WEB_ACCESS_ALL_TESTS, WEB_ACCESS_BENCHMARK_CONFIG } from "./tests.const.js";
@@ -13,6 +13,7 @@ interface CliOptions {
   concurrency?: number;
   providerConcurrency?: number;
   out?: string;
+  reportOut?: string;
   help: boolean;
 }
 
@@ -40,6 +41,9 @@ function parseArgs(argv: string[]): CliOptions {
       case "--out":
         opts.out = next();
         break;
+      case "--report-out":
+        opts.reportOut = next();
+        break;
       case "-h":
       case "--help":
         opts.help = true;
@@ -65,6 +69,7 @@ Options:
   --concurrency <n>    Parallel requests per provider (default: ${WEB_ACCESS_BENCHMARK_CONFIG.concurrency})
   --provider-concurrency <n>  Providers to benchmark at once (default: ${WEB_ACCESS_BENCHMARK_CONFIG.providerConcurrency})
   --out <file>         Results JSON path (default: results/benchmark-<timestamp>.json)
+  --report-out <file>  Rendered report path (default: the results path with a .txt extension)
   -h, --help           Show this help
 
 Set provider API keys in a .env file (see .env.example). A provider runs only when all of
@@ -90,6 +95,11 @@ function selectTests(opts: CliOptions): WebAccessTestConfig[] {
   if (!opts.tests) return WEB_ACCESS_ALL_TESTS;
   const wanted = new Set(opts.tests.map((t) => t.toLowerCase()));
   return WEB_ACCESS_ALL_TESTS.filter((t) => wanted.has(t.name.toLowerCase()));
+}
+
+function defaultReportPath(resultsPath: string): string {
+  const extension = extname(resultsPath);
+  return extension ? `${resultsPath.slice(0, -extension.length)}.txt` : `${resultsPath}.txt`;
 }
 
 async function main(): Promise<void> {
@@ -139,14 +149,17 @@ async function main(): Promise<void> {
   const providerWorkers = Math.min(config.providerConcurrency, active.length);
   await Promise.all(Array.from({ length: providerWorkers }, () => providerWorker()));
 
+  const report = formatComparisonReport(runs, config.timeoutMs);
   console.log("\n=== Comparison ===");
-  console.log(formatComparisonTable(runs, config.timeoutMs));
-  const comparisonResults = runs.map((run) => run.result);
-  for (const run of runs) console.log(formatProviderSummary(run, comparisonResults, config.timeoutMs));
+  console.log(report);
 
-  const outPath = opts.out ?? join("results", `benchmark-${new Date().toISOString().replace(/[:.]/g, "-")}.json`);
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const outPath = opts.out ?? join("results", `benchmark-${timestamp}.json`);
+  const reportPath = opts.reportOut ?? defaultReportPath(outPath);
   saveResultsJSON(runs, outPath);
+  saveComparisonReport(report, reportPath);
   console.log(`\nSaved results to ${outPath}`);
+  console.log(`Saved report to ${reportPath}`);
 }
 
 main().catch((e) => {

--- a/src/format.test.ts
+++ b/src/format.test.ts
@@ -1,11 +1,16 @@
 import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import test from "node:test";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   comparisonAverageLatencyMs,
   comparisonLatencyMs,
+  formatComparisonReport,
   formatProviderSummary,
   NO_SUCCESSFUL_PROVIDER_LATENCY_MS,
-  resolveComparisonLatency
+  resolveComparisonLatency,
+  saveComparisonReport
 } from "./format.js";
 import type { AttemptResult, WebAccessAggregatedResult, WebAccessBenchmarkResult } from "./types.js";
 
@@ -72,4 +77,20 @@ test("shows the resolved latency and its source in each target row", () => {
   assert.deepEqual(resolvedLatency, { latencyMs: 300, source: "successful providers" });
   assert.match(summary, /Resolved latency/);
   assert.match(summary, /0\.30s\s+successful providers\s+shared/);
+});
+
+test("writes the formatted comparison report", () => {
+  const directory = mkdtempSync(join(tmpdir(), "web-data-frontier-benchmark-"));
+  const outPath = join(directory, "reports", "comparison.txt");
+  const result = run(target("passed", [{ success: true, latencyMs: 100 }]));
+  const report = formatComparisonReport([{ provider: "provider", result }]);
+
+  try {
+    saveComparisonReport(report, outPath);
+    assert.equal(readFileSync(outPath, "utf8"), report);
+    assert.match(report, /Provider/);
+    assert.match(report, /successful attempts/);
+  } finally {
+    rmSync(directory, { force: true, recursive: true });
+  }
 });

--- a/src/format.ts
+++ b/src/format.ts
@@ -123,12 +123,31 @@ export function formatProviderSummary(
   return lines.join("\n");
 }
 
+export function formatComparisonReport(
+  runs: ProviderRun[],
+  noSuccessfulProviderLatencyMs = NO_SUCCESSFUL_PROVIDER_LATENCY_MS
+): string {
+  const comparisonResults = runs.map((run) => run.result);
+  return [
+    formatComparisonTable(runs, noSuccessfulProviderLatencyMs),
+    ...runs.map((run) => formatProviderSummary(run, comparisonResults, noSuccessfulProviderLatencyMs))
+  ].join("\n");
+}
+
+function writeOutput(outPath: string, contents: string): void {
+  mkdirSync(dirname(outPath), { recursive: true });
+  writeFileSync(outPath, contents);
+}
+
+export function saveComparisonReport(report: string, outPath: string): void {
+  writeOutput(outPath, report);
+}
+
 /** Persist the full structured results (every attempt) for later analysis. */
 export function saveResultsJSON(runs: ProviderRun[], outPath: string): void {
-  mkdirSync(dirname(outPath), { recursive: true });
   const payload = {
     generatedAt: new Date().toISOString(),
     providers: runs.map((r) => ({ provider: r.provider, ...r.result }))
   };
-  writeFileSync(outPath, JSON.stringify(payload, null, 2));
+  writeOutput(outPath, JSON.stringify(payload, null, 2));
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,9 +6,11 @@ export { PROVIDERS, getProvider } from "./providers/index.js";
 export {
   comparisonAverageLatencyMs,
   comparisonLatencyMs,
+  formatComparisonReport,
   formatComparisonTable,
   formatProviderSummary,
   resolveComparisonLatency,
+  saveComparisonReport,
   saveResultsJSON,
   type ProviderRun,
   type ResolvedLatency,

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,0 +1,3 @@
+# Lessons
+
+- Recalculate benchmark scoring changes from stored result JSON when raw attempts are available; do not rerun providers solely to update a report.

--- a/tasks/sessions/20260718-131915-persist-analysis-report.md
+++ b/tasks/sessions/20260718-131915-persist-analysis-report.md
@@ -6,7 +6,7 @@
 - [x] Add a reusable report writer and a results-only analysis command.
 - [x] Update the benchmark CLI to persist its rendered report.
 - [x] Add regression coverage and run validation.
-- [ ] Commit, push, and open a PR.
+- [x] Commit, push, and open a PR.
 
 ## Progress
 
@@ -21,3 +21,5 @@ Validation passed: `npm run typecheck`, `npm test`, `npm run analyze -- --help`,
 ## Review / results
 
 The analysis command recalculated the committed results without provider traffic and wrote `results/recalculated-latency.txt` in the worktree. The report begins with String at 95.8% / 11.07s and includes per-target latency sources.
+
+Opened [S-128690: Persist benchmark analysis reports](https://github.com/usestring/web-data-frontier-benchmark/pull/3) from `S-128690-persist-analysis-report-20260718-131915`.

--- a/tasks/sessions/20260718-131915-persist-analysis-report.md
+++ b/tasks/sessions/20260718-131915-persist-analysis-report.md
@@ -1,0 +1,23 @@
+# Persist benchmark and analysis reports
+
+## Plan
+
+- [x] Inspect the benchmark CLI, formatter, and result-file contract.
+- [x] Add a reusable report writer and a results-only analysis command.
+- [x] Update the benchmark CLI to persist its rendered report.
+- [x] Add regression coverage and run validation.
+- [ ] Commit, push, and open a PR.
+
+## Progress
+
+Created an isolated worktree from the merged `main` branch; the shared checkout's unrelated `bun.lock` remains untouched.
+
+The benchmark already persists raw attempt data as JSON. The change will preserve that contract, add a sibling rendered report file for benchmark runs, and add an `analyze` command that renders an existing JSON file without invoking providers.
+
+The benchmark CLI now writes a companion `.txt` report by default (or `--report-out`), while `npm run analyze` reads an existing JSON file and writes a report specified by `--out`.
+
+Validation passed: `npm run typecheck`, `npm test`, `npm run analyze -- --help`, `npm run benchmark -- --help`, and a results-only analysis run against the committed official JSON that wrote a 1,411-line report.
+
+## Review / results
+
+The analysis command recalculated the committed results without provider traffic and wrote `results/recalculated-latency.txt` in the worktree. The report begins with String at 95.8% / 11.07s and includes per-target latency sources.


### PR DESCRIPTION
## Summary

- Recalculate latency reports from stored benchmark JSON through `npm run analyze`, avoiding unnecessary provider calls and their cost.
- Persist a companion text report for every benchmark run while retaining the existing raw JSON output contract.
- Document both report-writing paths and cover report persistence with regression tests.

Fixes S-128690

## Test plan

- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run analyze -- --in official_results/benchmark-2026-07-15T21-36-21-625Z.json --out results/recalculated-latency.txt`
- [x] `npm run analyze -- --help`
- [x] `npm run benchmark -- --help`

## Agent Audit
- Action: create-pr
- Timestamp: 2026-07-18T17:28:50Z
- Agent: codex
- Agent type: codex
- Triggered by: loganharless
- Origin: loganharless@Mac
- Session: 019f72ff-5d0e-7891-b4f1-25e5ab2edfad
- Source repo: usestring/web-data-frontier-benchmark
- Worktree: /Users/loganharless/Desktop/da/worktrees/persist-analysis-report-20260718-131915
- Branch: S-128690-persist-analysis-report-20260718-131915
- Head commit: 94d2cd8
- tmux pane: %282
- tmux session: cld-89090-10998