### PR TITLE
S-125938: Add gitleaks and Husky secret checks

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,54 @@
+name: Gitleaks
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  gitleaks:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no_gha') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        env:
+          GITLEAKS_VERSION: 8.30.1
+        run: |
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C /usr/local/bin gitleaks
+          gitleaks version
+
+      - name: Restore gitleaks config from base branch
+        if: github.event_name == 'pull_request'
+        run: |
+          if git show "origin/${{ github.base_ref }}:.gitleaks.toml" 2>/dev/null > .gitleaks.toml.base; then
+            mv .gitleaks.toml.base .gitleaks.toml
+          else
+            rm -f .gitleaks.toml.base
+            echo "No .gitleaks.toml on base branch; using checked-out copy (bootstrap)."
+          fi
+
+          if git show "origin/${{ github.base_ref }}:.gitleaksignore" 2>/dev/null > .gitleaksignore; then
+            echo "Loaded .gitleaksignore from base branch."
+          else
+            rm -f .gitleaksignore
+            echo "No .gitleaksignore on base branch; fingerprint suppression disabled."
+          fi
+
+      - name: Scan PR / pushed commits for secrets
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          if ! git cat-file -e "$BASE_SHA^{commit}" 2>/dev/null; then
+            BASE_SHA="$HEAD_SHA~1"
+          fi
+          gitleaks git --no-banner --redact --ignore-gitleaks-allow --config .gitleaks.toml \
+            --log-opts="$BASE_SHA..$HEAD_SHA"

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,2 @@
+[extend]
+useDefault = true

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+gitleaks git --pre-commit --redact --staged --verbose

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "unblocker-benchmark",
+  "name": "web-data-frontier-benchmark",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "unblocker-benchmark",
+      "name": "web-data-frontier-benchmark",
       "version": "1.0.0",
       "dependencies": {
         "@browserbasehq/sdk": "2.8.0",
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@types/node": "22.10.5",
+        "husky": "^9.1.7",
         "tsx": "4.19.2",
         "typescript": "5.7.3"
       }
@@ -949,6 +950,22 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.0.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/is-plain-obj": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "benchmark": "tsx src/cli.ts",
     "typecheck": "tsc --noEmit",
     "build": "tsc",
-    "test": "npm run build && node --test dist/format.test.js"
+    "test": "npm run build && node --test dist/format.test.js",
+    "prepare": "husky"
   },
   "dependencies": {
     "@browserbasehq/sdk": "2.8.0",
@@ -24,6 +25,7 @@
   },
   "devDependencies": {
     "@types/node": "22.10.5",
+    "husky": "^9.1.7",
     "tsx": "4.19.2",
     "typescript": "5.7.3"
   },


### PR DESCRIPTION
## Summary

- Add a pinned Gitleaks workflow and default configuration so pull requests and default-branch pushes receive secret scanning.
- Add a Husky pre-commit hook that scans staged content with Gitleaks before it can be committed locally.

## Test plan

- [x] Validate the workflow with Prettier
- [x] Validate package-manager lockfiles
- [x] Exercise the Husky command with a controlled Gitleaks stub
- [x] Run the repository build or test suite where provided

Part of S-125938

## Agent Audit
- Action: create-pr
- Timestamp: 2026-07-21T20:18:15Z
- Agent: codex
- Agent type: codex
- Triggered by: loganharless
- Origin: loganharless@dev-vm
- Session: 019f8643-2ab0-7112-99cd-19471a75612b
- Source repo: usestring/web-data-frontier-benchmark
- Worktree: /home/loganharless/worktrees/s-125938-usestring-repos/web-data-frontier-benchmark
- Branch: s-125938-gitleaks-husky-20260721
- Head commit: 14157a6
- tmux pane: %8
- tmux session: cdx-3124802-79