### PR TITLE
Add MIT LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 String AI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -155,3 +155,7 @@ console.log(result.overallSuccessRate);
   where a provider only offers rendered output). See the per-file comments for the exact request shape.
 - Running the full suite across many providers makes real, billable API calls. Start with `--attempts 1`
   and a small `--tests` subset.
+
+## License
+
+[MIT](LICENSE) — re-run it, fork it, publish your own numbers. That's the point.


### PR DESCRIPTION
## Summary

**Why:** this repo has no LICENSE file, so default copyright applies — nobody can legally copy, modify, or redistribute it. That contradicts what the repo is *for*. The README tells people to re-run the suite and add their own providers, the launch post says ["we open-sourced a benchmark anyone can run"](https://www.usestring.ai/blog/web-scraping-benchmark-problem), and the whole credibility argument is that a competitor can verify our 95.8% themselves. Right now they can look, but they can't lawfully fork it to do so — and a competitor could fairly point that out.

Surfaced while writing the org profile README (S-130225), which links here as our flagship open-source artifact.

**What changed:**

- `LICENSE` — MIT, matching the rest of the org's OSS (`utils`, `string-ai-mcp`). GitHub will now show a "MIT" badge in the repo sidebar and expose it via the API, which is what most people actually check.
- A short `## License` section at the end of the README, since the invitation to re-run appears there.

**Why MIT and not something stronger:** the point of this repo is maximum reuse — the more people who fork it and publish numbers, the more the benchmark becomes a shared standard rather than our marketing. MIT imposes the least friction on that. Note `powhttp-mcp` is AGPL-3.0, which makes sense for a product-adjacent tool but would work against this one.

**One thing worth a decision, not blocking this PR:** the existing copyright holders disagree across the org — `utils/LICENSE` says `Copyright (c) 2026 usestring` while `string-ai-mcp/LICENSE` says `Copyright (c) 2026 String AI`. I used **String AI** here as the more entity-like of the two, but neither is obviously the registered name. Worth normalizing all three to whatever the actual legal entity is; happy to follow up once you confirm it.

Also still unlicensed: `relay-self-hosted`. Left alone deliberately — its README describes the sync engine as a fork of MIT-licensed y-sweet, so its licensing needs someone to check the upstream terms rather than a blanket MIT drop.

## Test plan

- [x] `LICENSE` is verbatim standard MIT (only holder/year substituted), so GitHub's licensee detection will classify it as `mit` rather than `other`.
- [x] Wording and structure match `usestring/utils/LICENSE` and `usestring/string-ai-mcp/LICENSE` — no bespoke terms introduced.
- [x] README addition is a leaf section at the end; no existing headings or anchors changed, so inbound links to the results table and provider docs still resolve.
- [x] No source files touched — the benchmark harness and official results are untouched by this PR.
- [ ] **After merge:** confirm the repo sidebar shows the MIT badge and `gh api repos/usestring/web-data-frontier-benchmark --jq .license.spdx_id` returns `MIT` (it currently returns `null`).

Fixes S-130238

## Agent Audit
- Action: create-pr
- Timestamp: 2026-07-26T04:39:29Z
- Agent: claude
- Agent type: claude
- Triggered by: loganharless
- Origin: loganharless@MacBook-Pro-5
- Session: cfdf9d1b-6e78-4093-b4eb-df6443125ac5
- Source repo: usestring/web-data-frontier-benchmark
- Worktree: /Users/loganharless/Desktop/da/worktrees/usestring-benchmark-license-20260726-003841
- Branch: s-130238-add-mit-license-20260726-003841
- Head commit: b00b7de
- tmux pane: %805
- tmux session: apc-12518-11403