### PR TITLE
S-130756: Require provider affiliation for benchmark configuration changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contributing
+
+Thanks for helping improve the Web Data Frontier Benchmark. Keep pull requests focused, explain how
+the change preserves a fair comparison, and include enough validation for maintainers to reproduce
+the result without exposing credentials.
+
+## Provider configuration changes
+
+The benchmark aims to exercise each provider using the configuration that provider currently
+recommends for this workload. To prevent unverified configuration changes from affecting the
+comparison, maintainers will approve a provider configuration change only after verifying that the
+contributor is currently affiliated with the company responsible for the affected provider.
+
+This requirement applies to any change that affects how a benchmarked provider runs, including:
+
+- adding or removing a provider;
+- changing a provider endpoint, request parameter, product or proxy mode, or response handling;
+- changing provider credentials, environment variables, activation, or registration; and
+- changing documentation that prescribes how a provider is configured for an official run.
+
+If a pull request affects more than one provider, affiliation must be verified for each affected
+company. If you are not affiliated with the affected company, open an issue with your evidence and
+recommendation instead; a verified company representative or maintainer can take responsibility for
+the configuration change.
+
+### Attestation and evidence
+
+Include this attestation in the pull request description:
+
+> I attest that I am currently affiliated with **[company]** and that this change reflects its
+> recommended configuration for this benchmark.
+
+The attestation must be accompanied by one of the following:
+
+- public membership in the provider's official GitHub organization, with a GitHub profile that
+  identifies the same company;
+- a link to an official company team page, staff profile, or announcement that identifies you; or
+- an email from your company-domain address to
+  [support@usestring.ai](mailto:support@usestring.ai) with the subject
+  `Benchmark affiliation verification for PR #<number>`. The message must include your GitHub
+  username, the company and provider, and the pull request URL.
+
+A self-attestation without verifiable evidence is not sufficient. If verification is sent by email,
+state that in the pull request without posting the private message or address. Maintainers will note
+on the pull request when verification is complete.
+
+Do not post or email API keys, account credentials, employee IDs, employment documents, contracts,
+or other sensitive personal information. Company-domain email ownership is sufficient for the
+email verification path.
+
+Verified affiliation is a prerequisite for approval, not a guarantee of acceptance. Maintainers
+will still review the change for fairness, reproducibility, scope, and consistency with the
+benchmark methodology.
+
+## Validation
+
+- Do not commit `.env` files, API keys, or raw credentials.
+- Start with a small provider-and-target smoke test before running a larger, billable benchmark.
+- Describe the commands run and their results in the pull request.
+- Keep official result updates separate from configuration changes unless maintainers request them.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,8 +20,9 @@ This requirement applies to any change that affects how a benchmarked provider r
 
 If a pull request affects more than one provider, affiliation must be verified for each affected
 company. If you are not affiliated with the affected company, open an issue with your evidence and
-recommendation instead; a verified company representative or maintainer can take responsibility for
-the configuration change.
+recommendation instead. Maintainers may use the issue to invite a verified company representative
+to submit the configuration change, but will not approve a provider configuration pull request from
+an unaffiliated contributor.
 
 ### Attestation and evidence
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,15 +30,20 @@ Include this attestation in the pull request description:
 > I attest that I am currently affiliated with **[company]** and that this change reflects its
 > recommended configuration for this benchmark.
 
-The attestation must be accompanied by one of the following:
+The evidence must directly bind the GitHub account that opened the pull request to the affected
+company. A matching name, a self-edited profile employer field, a company team directory or roster,
+a LinkedIn page, or another page that merely lists someone with the same name is not sufficient.
 
-- public membership in the provider's official GitHub organization, with a GitHub profile that
-  identifies the same company;
-- a link to an official company team page, staff profile, or announcement that identifies you; or
-- an email from your company-domain address to
+Use one of these verification paths:
+
+- Make the pull request author's membership in the provider's official GitHub organization public
+  on the same GitHub account that opened the pull request.
+- Send an email from your company-domain address to
   [support@usestring.ai](mailto:support@usestring.ai) with the subject
   `Benchmark affiliation verification for PR #<number>`. The message must include your GitHub
-  username, the company and provider, and the pull request URL.
+  username, the company and provider, and the pull request URL. A maintainer will reply with a
+  one-time verification phrase; post that phrase on the pull request from the account that opened
+  it to complete verification.
 
 A self-attestation without verifiable evidence is not sufficient. If verification is sent by email,
 state that in the pull request without posting the private message or address. Maintainers will note

--- a/README.md
+++ b/README.md
@@ -142,6 +142,12 @@ const result = await runWebAccessBenchmarkSuite(WEB_ACCESS_ALL_TESTS, makeExecut
 console.log(result.overallSuccessRate);
 ```
 
+## Contributing
+
+Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request. Maintainers approve provider
+configuration changes only after verifying the contributor's current affiliation with the affected
+provider's company.
+
 ## Adding a provider
 
 1. Create `src/providers/<name>.ts` exporting a `Provider` (`name`, `envKeys`, `fetch`).

--- a/tasks/sessions/20260728-204224-provider-affiliation-policy.md
+++ b/tasks/sessions/20260728-204224-provider-affiliation-policy.md
@@ -1,0 +1,27 @@
+# Require provider affiliation for configuration changes
+
+## Checklist
+
+- [x] Inspect the repository's existing contribution and benchmark documentation.
+- [x] Review the open Firecrawl configuration pull request for concrete policy coverage.
+- [x] Add a contribution guide with affiliation attestation and verification requirements.
+- [x] Link the guide from the README.
+- [x] Validate the documentation diff and repository checks.
+- [ ] Commit, push, and open a ready-for-review pull request.
+
+## Progress
+
+The repository did not have a contribution guide. The new policy makes verified current affiliation
+with each affected benchmark provider's company a prerequisite for approving provider configuration
+changes. It accepts public evidence or a minimal company-domain email sent only to String's existing
+public support address, while prohibiting secrets and sensitive employment records.
+
+The change is limited to contribution policy and discoverability. It does not modify provider
+configuration, target fixtures, or official benchmark results.
+
+## Results
+
+`git diff --check` passed, every changed Markdown line is within the repository's 140-character
+Prettier limit, and the README link resolves to the new tracked guide. Runtime tests were not run
+because this is a documentation-only change and the disposable checkout has no installed
+dependencies.

--- a/tasks/sessions/20260728-204224-provider-affiliation-policy.md
+++ b/tasks/sessions/20260728-204224-provider-affiliation-policy.md
@@ -21,6 +21,10 @@ fields, team rosters, and similar listings. Accepted evidence now binds the pull
 GitHub account directly through public membership in the provider's official GitHub organization or
 a company-domain email plus a one-time phrase posted from the pull request author's account.
 
+The unaffiliated-contributor fallback was also clarified: maintainers may invite a verified company
+representative to submit the change, but cannot bypass the affiliation requirement by taking over
+the pull request themselves.
+
 The change is limited to contribution policy and discoverability. It does not modify provider
 configuration, target fixtures, or official benchmark results.
 

--- a/tasks/sessions/20260728-204224-provider-affiliation-policy.md
+++ b/tasks/sessions/20260728-204224-provider-affiliation-policy.md
@@ -7,7 +7,7 @@
 - [x] Add a contribution guide with affiliation attestation and verification requirements.
 - [x] Link the guide from the README.
 - [x] Validate the documentation diff and repository checks.
-- [ ] Commit, push, and open a ready-for-review pull request.
+- [x] Commit, push, and open a ready-for-review pull request.
 
 ## Progress
 
@@ -25,3 +25,6 @@ configuration, target fixtures, or official benchmark results.
 Prettier limit, and the README link resolves to the new tracked guide. Runtime tests were not run
 because this is a documentation-only change and the disposable checkout has no installed
 dependencies.
+
+Opened [PR #8](https://github.com/usestring/web-data-frontier-benchmark/pull/8) as a ready-for-review
+pull request linked to S-130756.

--- a/tasks/sessions/20260728-204224-provider-affiliation-policy.md
+++ b/tasks/sessions/20260728-204224-provider-affiliation-policy.md
@@ -16,6 +16,11 @@ with each affected benchmark provider's company a prerequisite for approving pro
 changes. It accepts public evidence or a minimal company-domain email sent only to String's existing
 public support address, while prohibiting secrets and sensitive employment records.
 
+After review, the evidence language was tightened to reject name matches, self-edited profile
+fields, team rosters, and similar listings. Accepted evidence now binds the pull request author's
+GitHub account directly through public membership in the provider's official GitHub organization or
+a company-domain email plus a one-time phrase posted from the pull request author's account.
+
 The change is limited to contribution policy and discoverability. It does not modify provider
 configuration, target fixtures, or official benchmark results.
 


### PR DESCRIPTION
## Summary

- protect benchmark fairness by requiring verified current affiliation before approving changes to an affected provider's configuration
- define public and company-domain-email verification paths while directing private verification only to String's existing public support address
- link the new contribution policy from the README without changing provider adapters, target fixtures, or official results

## Test plan

- [x] `git diff --check`
- [x] confirmed changed Markdown lines stay within the repository's 140-character Prettier limit
- [x] confirmed the README link resolves to `CONTRIBUTING.md`
- [x] confirmed the diff contains documentation only

Fixes S-130756

## Agent Audit
- Action: create-pr
- Timestamp: 2026-07-29T00:46:27Z
- Agent: codex
- Agent type: codex
- Triggered by: loganharless
- Origin: loganharless@MacBook-Pro-5
- Session: 019fab4d-eaf9-7661-b3f8-c1ae66d1c051
- Source repo: usestring/web-data-frontier-benchmark
- Worktree: /Users/loganharless/Desktop/da/worktrees/web-data-frontier-contributing-20260728-203934
- Branch: s-130756-provider-affiliation-policy-20260728-204224
- Head commit: 0dffd9e
- tmux pane: %1026
- tmux session: cdx-6047-10778