### PR TITLE
S-130781: Clarify maintainer exception to affiliation policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,9 +7,14 @@ the result without exposing credentials.
 ## Provider configuration changes
 
 The benchmark aims to exercise each provider using the configuration that provider currently
-recommends for this workload. To prevent unverified configuration changes from affecting the
-comparison, maintainers will approve a provider configuration change only after verifying that the
-contributor is currently affiliated with the company responsible for the affected provider.
+recommends for this workload. To prevent unverified external configuration changes from affecting
+the comparison, maintainers will approve a provider configuration change from an external
+contributor only after verifying that the contributor is currently affiliated with the company
+responsible for the affected provider.
+
+Repository maintainers may bypass the affiliation requirement. A maintainer may implement a
+configuration change directly or explicitly state on an external pull request that they are taking
+responsibility for the change. Routine review does not silently invoke this exception.
 
 This requirement applies to any change that affects how a benchmarked provider runs, including:
 
@@ -18,15 +23,15 @@ This requirement applies to any change that affects how a benchmarked provider r
 - changing provider credentials, environment variables, activation, or registration; and
 - changing documentation that prescribes how a provider is configured for an official run.
 
-If a pull request affects more than one provider, affiliation must be verified for each affected
-company. If you are not affiliated with the affected company, open an issue with your evidence and
-recommendation instead. Maintainers may use the issue to invite a verified company representative
-to submit the configuration change, but will not approve a provider configuration pull request from
-an unaffiliated contributor.
+Unless a repository maintainer invokes the exception, affiliation must be verified for each company
+affected by a pull request. If you are not affiliated with the affected company, open an issue with
+your evidence and recommendation instead, or ask a repository maintainer to explicitly take
+responsibility for the configuration change.
 
 ### Attestation and evidence
 
-Include this attestation in the pull request description:
+Unless a repository maintainer has explicitly taken responsibility for the change, include this
+attestation in the pull request description:
 
 > I attest that I am currently affiliated with **[company]** and that this change reflects its
 > recommended configuration for this benchmark.
@@ -54,9 +59,9 @@ Do not post or email API keys, account credentials, employee IDs, employment doc
 or other sensitive personal information. Company-domain email ownership is sufficient for the
 email verification path.
 
-Verified affiliation is a prerequisite for approval, not a guarantee of acceptance. Maintainers
-will still review the change for fairness, reproducibility, scope, and consistency with the
-benchmark methodology.
+For external contributors without an explicit maintainer exception, verified affiliation is a
+prerequisite for approval, not a guarantee of acceptance. Maintainers will still review every
+change for fairness, reproducibility, scope, and consistency with the benchmark methodology.
 
 ## Validation
 

--- a/README.md
+++ b/README.md
@@ -145,8 +145,9 @@ console.log(result.overallSuccessRate);
 ## Contributing
 
 Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request. Maintainers approve provider
-configuration changes only after verifying the contributor's current affiliation with the affected
-provider's company.
+configuration changes from external contributors only after verifying current affiliation with the
+affected provider's company, unless a repository maintainer explicitly takes responsibility for
+the change.
 
 ## Adding a provider
 

--- a/tasks/sessions/20260729-003209-maintainer-affiliation-exception.md
+++ b/tasks/sessions/20260729-003209-maintainer-affiliation-exception.md
@@ -6,7 +6,7 @@
 - [x] Define an explicit maintainer exception without weakening external identity verification.
 - [x] Update the contribution guide and README.
 - [x] Validate the documentation diff.
-- [ ] Commit, push, and open a ready-for-review pull request.
+- [x] Commit, push, and open a ready-for-review pull request.
 
 ## Progress
 
@@ -22,3 +22,6 @@ use the maintainer exception.
 `git diff --check` passed, all changed Markdown lines remain within the repository's 140-character
 Prettier limit, and the contribution guide and README describe the same maintainer exception.
 Runtime tests were not run because the change is documentation-only.
+
+Opened [PR #9](https://github.com/usestring/web-data-frontier-benchmark/pull/9) as a ready-for-review
+pull request linked to S-130781.

--- a/tasks/sessions/20260729-003209-maintainer-affiliation-exception.md
+++ b/tasks/sessions/20260729-003209-maintainer-affiliation-exception.md
@@ -1,0 +1,24 @@
+# Clarify the maintainer affiliation exception
+
+## Checklist
+
+- [x] Inspect the merged affiliation policy and README summary.
+- [x] Define an explicit maintainer exception without weakening external identity verification.
+- [x] Update the contribution guide and README.
+- [x] Validate the documentation diff.
+- [ ] Commit, push, and open a ready-for-review pull request.
+
+## Progress
+
+The affiliation requirement now applies to external contributors by default. Repository maintainers
+may implement configuration changes directly or explicitly state that they are taking responsibility
+for an external pull request. Routine review does not silently invoke the exception.
+
+The existing identity-bound evidence paths remain unchanged for external contributions that do not
+use the maintainer exception.
+
+## Results
+
+`git diff --check` passed, all changed Markdown lines remain within the repository's 140-character
+Prettier limit, and the contribution guide and README describe the same maintainer exception.
+Runtime tests were not run because the change is documentation-only.


### PR DESCRIPTION
## Summary

- clarify that affiliation verification applies to external provider-configuration contributors, while repository maintainers may bypass it
- require maintainers to implement the change directly or explicitly take responsibility on the pull request so the exception remains auditable
- align the README summary without weakening identity-bound evidence requirements for other external contributions

## Test plan

- [x] `git diff --check`
- [x] confirmed changed Markdown lines stay within the repository's 140-character Prettier limit
- [x] confirmed `CONTRIBUTING.md` and `README.md` describe the same maintainer exception
- [x] confirmed the diff contains documentation only

Fixes S-130781

## Agent Audit
- Action: create-pr
- Timestamp: 2026-07-29T04:34:46Z
- Agent: codex
- Agent type: codex
- Triggered by: loganharless
- Origin: loganharless@Mac
- Session: 019fab4d-eaf9-7661-b3f8-c1ae66d1c051
- Source repo: usestring/web-data-frontier-benchmark
- Worktree: /Users/loganharless/Desktop/da/worktrees/web-data-frontier-maintainer-exception-20260729-003209
- Branch: s-130781-maintainer-affiliation-exception-20260729-003209
- Head commit: 99218f4
- tmux pane: %1026
- tmux session: cdx-6047-10778