### PR TITLE
S-130862: Simplify company email affiliation verification

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,9 +47,9 @@ Use one of these verification paths:
 - Send an email from your company-domain address to
   [support@usestring.ai](mailto:support@usestring.ai) with the subject
   `Benchmark affiliation verification for PR #<number>`. The message must include your GitHub
-  username, the company and provider, and the pull request URL. A maintainer will reply with a
-  one-time verification phrase; post that phrase on the pull request from the account that opened
-  it to complete verification.
+  username, the company and provider, the pull request URL, and confirmation that you want the
+  provider configuration in that pull request merged. Receipt of that company-domain email is
+  sufficient verification; no public challenge is required.
 
 A self-attestation without verifiable evidence is not sufficient. If verification is sent by email,
 state that in the pull request without posting the private message or address. Maintainers will note

--- a/tasks/sessions/20260729-091158-simplify-email-verification.md
+++ b/tasks/sessions/20260729-091158-simplify-email-verification.md
@@ -6,7 +6,7 @@
 - [x] Remove the one-time verification phrase.
 - [x] Define the sufficient company-domain email contents.
 - [x] Validate the documentation diff.
-- [ ] Commit, push, and open a ready-for-review pull request.
+- [x] Commit, push, and open a ready-for-review pull request.
 
 ## Progress
 
@@ -19,3 +19,6 @@ configuration merged. The policy no longer requires a public phrase or follow-up
 `git diff --check` passed, all changed Markdown lines remain within the repository's 140-character
 Prettier limit, and the diff changes documentation only. Runtime tests were not run because the
 change has no runtime behavior.
+
+Opened [PR #11](https://github.com/usestring/web-data-frontier-benchmark/pull/11) as a
+ready-for-review pull request linked to S-130862.

--- a/tasks/sessions/20260729-091158-simplify-email-verification.md
+++ b/tasks/sessions/20260729-091158-simplify-email-verification.md
@@ -1,0 +1,21 @@
+# Simplify company email affiliation verification
+
+## Checklist
+
+- [x] Inspect the merged affiliation policy.
+- [x] Remove the one-time verification phrase.
+- [x] Define the sufficient company-domain email contents.
+- [x] Validate the documentation diff.
+- [ ] Commit, push, and open a ready-for-review pull request.
+
+## Progress
+
+Company-domain email is now sufficient evidence when it identifies the GitHub contributor, company
+and provider, pull request, and confirms that the sender wants that pull request's provider
+configuration merged. The policy no longer requires a public phrase or follow-up challenge.
+
+## Results
+
+`git diff --check` passed, all changed Markdown lines remain within the repository's 140-character
+Prettier limit, and the diff changes documentation only. Runtime tests were not run because the
+change has no runtime behavior.


### PR DESCRIPTION
## Summary

- remove the one-time public challenge because a company-domain email already establishes the relevant affiliation and intent
- require the email to identify the contributor, provider, pull request, and confirm that its provider configuration should be merged
- leave public GitHub-organization verification and the maintainer exception unchanged

## Test plan

- [x] `git diff --check`
- [x] confirmed changed Markdown lines stay within the repository's 140-character Prettier limit
- [x] confirmed the diff contains documentation only

Fixes S-130862

## Agent Audit
- Action: create-pr
- Timestamp: 2026-07-29T13:14:33Z
- Agent: codex
- Agent type: codex
- Triggered by: loganharless
- Origin: loganharless@Mac
- Session: 019fab4d-eaf9-7661-b3f8-c1ae66d1c051
- Source repo: usestring/web-data-frontier-benchmark
- Worktree: /Users/loganharless/Desktop/da/worktrees/web-data-frontier-email-verification-20260729-091158
- Branch: s-130862-simplify-email-verification-20260729-091158
- Head commit: 75cc406
- tmux pane: %1026
- tmux session: cdx-6047-10778