### PR TITLE
Name Relativity Labs Inc. as the copyright holder

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 String AI
+Copyright (c) 2026 Relativity Labs Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Names the registered legal entity — **Relativity Labs Inc.** (d/b/a String) — as the copyright
holder, replacing the informal name in the MIT header. No change to the license itself or to any
grant; the MIT terms and the 2026 year are untouched.

The org previously disagreed with itself: `utils` read `usestring`, while `string-ai-mcp` and
`web-data-frontier-benchmark` read `String AI`. Neither is the entity that actually holds the
copyright. Sibling PRs normalise the other repos to the same line.

Part of S-130248.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Agent Audit
- Action: create-pr
- Timestamp: 2026-08-12T19:12:24Z
- Agent: claude
- Agent type: claude
- Triggered by: loganharless
- Origin: loganharless@dev-vm
- Session: 7b578a38-9f21-4b69-ab8b-4666ab58f927
- Source repo: usestring/web-data-frontier-benchmark
- Worktree: /tmp/claude-1000/-home-loganharless-dsrc/7b578a38-9f21-4b69-ab8b-4666ab58f927/scratchpad/clone-web-data-frontier-benchmark
- Branch: s-130248-copyright-holder
- Head commit: cb43888
- tmux pane: %2